### PR TITLE
build docker image and upload to ghcr.io

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,6 @@ node_modules
 Dockerfile
 .dockerignore
 *.log
+.github
+snaps
+README.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build-image:
+    runs-on: ubuntu-latest
+    name: "Build image"
+    steps:
+    - name: "Checkout code"
+      uses: actions/checkout@v6
+    - name: "Build the Docker image"
+      run: | 
+        docker build . \
+        --tag ghcr.io/mejaz/spicedb-ui:${{ github.sha }} \
+        --tag ghcr.io/mejaz/spicedb-ui:latest
+    - name: "Login to GitHub Container Registry"
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      uses: docker/login-action@v4
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: "Push the Docker image"
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      run: docker push ghcr.io/mejaz/spicedb-ui --all-tags

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Node.js runtime as a parent image
-FROM node:25-alpine
+FROM node:24-alpine
 
 # Set working directory
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Node.js runtime as a parent image
-FROM node:18-alpine
+FROM node:25-alpine
 
 # Set working directory
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -52,6 +52,24 @@ A modern web interface for managing SpiceDB authorization systems. Built with Ne
 
 ## Quick Start
 
+### Use pre-built images
+
+The project creates automatic Docker builds on every new commit to the main branch.
+
+```yaml
+# docker-compose.yml
+services:
+  spicedb-ui:
+    image: ghcr.io/mejaz/spicedb-ui:latest
+    ports:
+      - "3000:3000"
+    environment:
+      - SPICEDB_URL=http://host.docker.internal:8443
+      - SPICEDB_TOKEN=your-token-here
+```
+
+### Building the Image during for development
+
 1. **Clone and install**
    ```bash
    git clone https://github.com/mejaz/spicedb-ui.git
@@ -83,7 +101,12 @@ A modern web interface for managing SpiceDB authorization systems. Built with Ne
 
 ### Run with Docker
 
-1. **Configure environment variables**
+1. **Build the Docker image**
+   ```bash
+   docker build -t spicedb-ui .
+   ```
+
+2. **Configure environment variables**
 
    Create a `.env` file in the project root:
    ```bash
@@ -94,12 +117,12 @@ A modern web interface for managing SpiceDB authorization systems. Built with Ne
 
    > **Note**: Use `host.docker.internal` to connect to services running on your host machine from within the Docker container.
 
-2. **Run the container**
+3. **Run the container**
    ```bash
-   docker run --env-file .env -p 3000:3000 ghcr.io/mejaz/spicedb-ui
+   docker run --env-file .env -p 3000:3000 spicedb-ui
    ```
 
-3. **Access the application**
+4. **Access the application**
 
    Open your browser and navigate to `http://localhost:3000`
 
@@ -111,10 +134,9 @@ For easier management, you can also use Docker Compose:
 
 ```yaml
 # docker-compose.yml
-version: '3.8'
 services:
   spicedb-ui:
-    image: ghcr.io/mejaz/spicedb-ui:latest
+    build: .
     ports:
       - "3000:3000"
     environment:
@@ -124,7 +146,7 @@ services:
 
 Then run:
 ```bash
-docker-compose up
+docker-compose up --build
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -83,12 +83,7 @@ A modern web interface for managing SpiceDB authorization systems. Built with Ne
 
 ### Run with Docker
 
-1. **Build the Docker image**
-   ```bash
-   docker build -t spicedb-ui .
-   ```
-
-2. **Configure environment variables**
+1. **Configure environment variables**
 
    Create a `.env` file in the project root:
    ```bash
@@ -99,12 +94,12 @@ A modern web interface for managing SpiceDB authorization systems. Built with Ne
 
    > **Note**: Use `host.docker.internal` to connect to services running on your host machine from within the Docker container.
 
-3. **Run the container**
+2. **Run the container**
    ```bash
-   docker run --env-file .env -p 3000:3000 spicedb-ui
+   docker run --env-file .env -p 3000:3000 ghcr.io/mejaz/spicedb-ui
    ```
 
-4. **Access the application**
+3. **Access the application**
 
    Open your browser and navigate to `http://localhost:3000`
 
@@ -119,7 +114,7 @@ For easier management, you can also use Docker Compose:
 version: '3.8'
 services:
   spicedb-ui:
-    build: .
+    image: ghcr.io/mejaz/spicedb-ui:latest
     ports:
       - "3000:3000"
     environment:
@@ -129,7 +124,7 @@ services:
 
 Then run:
 ```bash
-docker-compose up --build
+docker-compose up
 ```
 
 ## Configuration


### PR DESCRIPTION
- https://github.com/mejaz/spicedb-ui/issues/2

This pr adds a GitHub workflow that builds the docker image with the tags `latest` and git commit hash and uploads it to the GitHub container registry. I configured the CI to run on PRs that target the `main` branch as well to verify that an image can be generated successfully. The image will only push to the registry on the main branch, though.

Additionally, I bumped NodeJS to 25 and updated the README.md file. The image uri will be:
```
 ghcr.io/mejaz/spicedb-ui
```

I tested the CI on my forked repository: https://github.com/josxha/spicedb-ui/pkgs/container/spicedb-ui. It can be tested by using:

```yaml
services:
  spicedb-ui:
    image: ghcr.io/josxha/spicedb-ui:latest # in this pr mejaz/spicedb-ui
    ports: [ "127.0.0.1:3000:3000" ]
    environment:
      - SPICEDB_URL=http://spicedb:8443
      - SPICEDB_TOKEN=your-token
```